### PR TITLE
Add support for Instance Private Networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Here is the list of supported configuration parameters by the builder.
 - `instance_security_group` (string) - Security Group to use for the Compute
   instance. Defaults to `default`.
 
+- `instance_private_networks` (list of strings) - List of Private Networks
+  (names) to attach to the Compute instance.
+
 - `instance_ssh_key` (string) - Name of the Exoscale SSH key to use with the
   Compute instance. If unset, a throwaway SSH key named `packer-<BUILD ID>`
   will be created before creating the instance, and destroyed after a

--- a/config.go
+++ b/config.go
@@ -29,28 +29,29 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 
-	APIEndpoint             string `mapstructure:"api_endpoint"`
-	APIKey                  string `mapstructure:"api_key"`
-	APISecret               string `mapstructure:"api_secret"`
-	InstanceName            string `mapstructure:"instance_name"`
-	InstanceZone            string `mapstructure:"instance_zone"`
-	InstanceTemplate        string `mapstructure:"instance_template"`
-	InstanceTemplateFilter  string `mapstructure:"instance_template_filter"`
-	InstanceType            string `mapstructure:"instance_type"`
-	InstanceDiskSize        int64  `mapstructure:"instance_disk_size"`
-	InstanceSecurityGroup   string `mapstructure:"instance_security_group"`
-	InstanceSSHKey          string `mapstructure:"instance_ssh_key"`
-	TemplateZone            string `mapstructure:"template_zone"`
-	TemplateName            string `mapstructure:"template_name"`
-	TemplateDescription     string `mapstructure:"template_description"`
-	TemplateUsername        string `mapstructure:"template_username"`
-	TemplateBootMode        string `mapstructure:"template_boot_mode"`
-	TemplateDisablePassword bool   `mapstructure:"template_disable_password"`
-	TemplateDisableSSHKey   bool   `mapstructure:"template_disable_sshkey"`
+	APIEndpoint             string   `mapstructure:"api_endpoint"`
+	APIKey                  string   `mapstructure:"api_key"`
+	APISecret               string   `mapstructure:"api_secret"`
+	InstanceName            string   `mapstructure:"instance_name"`
+	InstanceZone            string   `mapstructure:"instance_zone"`
+	InstanceTemplate        string   `mapstructure:"instance_template"`
+	InstanceTemplateFilter  string   `mapstructure:"instance_template_filter"`
+	InstanceType            string   `mapstructure:"instance_type"`
+	InstanceDiskSize        int64    `mapstructure:"instance_disk_size"`
+	InstanceSecurityGroup   string   `mapstructure:"instance_security_group"`
+	InstancePrivateNetworks []string `mapstructure:"instance_private_networks"`
+	InstanceSSHKey          string   `mapstructure:"instance_ssh_key"`
+	TemplateZone            string   `mapstructure:"template_zone"`
+	TemplateName            string   `mapstructure:"template_name"`
+	TemplateDescription     string   `mapstructure:"template_description"`
+	TemplateUsername        string   `mapstructure:"template_username"`
+	TemplateBootMode        string   `mapstructure:"template_boot_mode"`
+	TemplateDisablePassword bool     `mapstructure:"template_disable_password"`
+	TemplateDisableSSHKey   bool     `mapstructure:"template_disable_sshkey"`
 }
 
 func NewConfig(raws ...interface{}) (*Config, error) {
-	var config = Config{
+	config := Config{
 		APIEndpoint:            defaultAPIEndpoint,
 		InstanceType:           defaultInstanceType,
 		InstanceDiskSize:       defaultInstanceDiskSize,

--- a/config.hcl2spec.go
+++ b/config.hcl2spec.go
@@ -9,73 +9,74 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
-	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
-	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
-	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
-	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
-	PackerUserVars            map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
-	PackerSensitiveVars       []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	Type                      *string           `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
-	PauseBeforeConnect        *string           `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
-	SSHHost                   *string           `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
-	SSHPort                   *int              `mapstructure:"ssh_port" cty:"ssh_port" hcl:"ssh_port"`
-	SSHUsername               *string           `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
-	SSHPassword               *string           `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
-	SSHKeyPairName            *string           `mapstructure:"ssh_keypair_name" cty:"ssh_keypair_name" hcl:"ssh_keypair_name"`
-	SSHTemporaryKeyPairName   *string           `mapstructure:"temporary_key_pair_name" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
-	SSHClearAuthorizedKeys    *bool             `mapstructure:"ssh_clear_authorized_keys" cty:"ssh_clear_authorized_keys" hcl:"ssh_clear_authorized_keys"`
-	SSHPrivateKeyFile         *string           `mapstructure:"ssh_private_key_file" cty:"ssh_private_key_file" hcl:"ssh_private_key_file"`
-	SSHPty                    *bool             `mapstructure:"ssh_pty" cty:"ssh_pty" hcl:"ssh_pty"`
-	SSHTimeout                *string           `mapstructure:"ssh_timeout" cty:"ssh_timeout" hcl:"ssh_timeout"`
-	SSHWaitTimeout            *string           `mapstructure:"ssh_wait_timeout" undocumented:"true" cty:"ssh_wait_timeout" hcl:"ssh_wait_timeout"`
-	SSHAgentAuth              *bool             `mapstructure:"ssh_agent_auth" cty:"ssh_agent_auth" hcl:"ssh_agent_auth"`
-	SSHDisableAgentForwarding *bool             `mapstructure:"ssh_disable_agent_forwarding" cty:"ssh_disable_agent_forwarding" hcl:"ssh_disable_agent_forwarding"`
-	SSHHandshakeAttempts      *int              `mapstructure:"ssh_handshake_attempts" cty:"ssh_handshake_attempts" hcl:"ssh_handshake_attempts"`
-	SSHBastionHost            *string           `mapstructure:"ssh_bastion_host" cty:"ssh_bastion_host" hcl:"ssh_bastion_host"`
-	SSHBastionPort            *int              `mapstructure:"ssh_bastion_port" cty:"ssh_bastion_port" hcl:"ssh_bastion_port"`
-	SSHBastionAgentAuth       *bool             `mapstructure:"ssh_bastion_agent_auth" cty:"ssh_bastion_agent_auth" hcl:"ssh_bastion_agent_auth"`
-	SSHBastionUsername        *string           `mapstructure:"ssh_bastion_username" cty:"ssh_bastion_username" hcl:"ssh_bastion_username"`
-	SSHBastionPassword        *string           `mapstructure:"ssh_bastion_password" cty:"ssh_bastion_password" hcl:"ssh_bastion_password"`
-	SSHBastionInteractive     *bool             `mapstructure:"ssh_bastion_interactive" cty:"ssh_bastion_interactive" hcl:"ssh_bastion_interactive"`
-	SSHBastionPrivateKeyFile  *string           `mapstructure:"ssh_bastion_private_key_file" cty:"ssh_bastion_private_key_file" hcl:"ssh_bastion_private_key_file"`
-	SSHFileTransferMethod     *string           `mapstructure:"ssh_file_transfer_method" cty:"ssh_file_transfer_method" hcl:"ssh_file_transfer_method"`
-	SSHProxyHost              *string           `mapstructure:"ssh_proxy_host" cty:"ssh_proxy_host" hcl:"ssh_proxy_host"`
-	SSHProxyPort              *int              `mapstructure:"ssh_proxy_port" cty:"ssh_proxy_port" hcl:"ssh_proxy_port"`
-	SSHProxyUsername          *string           `mapstructure:"ssh_proxy_username" cty:"ssh_proxy_username" hcl:"ssh_proxy_username"`
-	SSHProxyPassword          *string           `mapstructure:"ssh_proxy_password" cty:"ssh_proxy_password" hcl:"ssh_proxy_password"`
-	SSHKeepAliveInterval      *string           `mapstructure:"ssh_keep_alive_interval" cty:"ssh_keep_alive_interval" hcl:"ssh_keep_alive_interval"`
-	SSHReadWriteTimeout       *string           `mapstructure:"ssh_read_write_timeout" cty:"ssh_read_write_timeout" hcl:"ssh_read_write_timeout"`
-	SSHRemoteTunnels          []string          `mapstructure:"ssh_remote_tunnels" cty:"ssh_remote_tunnels" hcl:"ssh_remote_tunnels"`
-	SSHLocalTunnels           []string          `mapstructure:"ssh_local_tunnels" cty:"ssh_local_tunnels" hcl:"ssh_local_tunnels"`
-	SSHPublicKey              []byte            `mapstructure:"ssh_public_key" cty:"ssh_public_key" hcl:"ssh_public_key"`
-	SSHPrivateKey             []byte            `mapstructure:"ssh_private_key" cty:"ssh_private_key" hcl:"ssh_private_key"`
-	WinRMUser                 *string           `mapstructure:"winrm_username" cty:"winrm_username" hcl:"winrm_username"`
-	WinRMPassword             *string           `mapstructure:"winrm_password" cty:"winrm_password" hcl:"winrm_password"`
-	WinRMHost                 *string           `mapstructure:"winrm_host" cty:"winrm_host" hcl:"winrm_host"`
-	WinRMPort                 *int              `mapstructure:"winrm_port" cty:"winrm_port" hcl:"winrm_port"`
-	WinRMTimeout              *string           `mapstructure:"winrm_timeout" cty:"winrm_timeout" hcl:"winrm_timeout"`
-	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
-	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
-	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	APIEndpoint               *string           `mapstructure:"api_endpoint" cty:"api_endpoint" hcl:"api_endpoint"`
-	APIKey                    *string           `mapstructure:"api_key" cty:"api_key" hcl:"api_key"`
-	APISecret                 *string           `mapstructure:"api_secret" cty:"api_secret" hcl:"api_secret"`
-	InstanceName              *string           `mapstructure:"instance_name" cty:"instance_name" hcl:"instance_name"`
-	InstanceZone              *string           `mapstructure:"instance_zone" cty:"instance_zone" hcl:"instance_zone"`
-	InstanceTemplate          *string           `mapstructure:"instance_template" cty:"instance_template" hcl:"instance_template"`
-	InstanceTemplateFilter    *string           `mapstructure:"instance_template_filter" cty:"instance_template_filter" hcl:"instance_template_filter"`
-	InstanceType              *string           `mapstructure:"instance_type" cty:"instance_type" hcl:"instance_type"`
-	InstanceDiskSize          *int64            `mapstructure:"instance_disk_size" cty:"instance_disk_size" hcl:"instance_disk_size"`
-	InstanceSecurityGroup     *string           `mapstructure:"instance_security_group" cty:"instance_security_group" hcl:"instance_security_group"`
-	InstanceSSHKey            *string           `mapstructure:"instance_ssh_key" cty:"instance_ssh_key" hcl:"instance_ssh_key"`
-	TemplateZone              *string           `mapstructure:"template_zone" cty:"template_zone" hcl:"template_zone"`
-	TemplateName              *string           `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
-	TemplateDescription       *string           `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
-	TemplateUsername          *string           `mapstructure:"template_username" cty:"template_username" hcl:"template_username"`
-	TemplateBootMode          *string           `mapstructure:"template_boot_mode" cty:"template_boot_mode" hcl:"template_boot_mode"`
-	TemplateDisablePassword   *bool             `mapstructure:"template_disable_password" cty:"template_disable_password" hcl:"template_disable_password"`
-	TemplateDisableSSHKey     *bool             `mapstructure:"template_disable_sshkey" cty:"template_disable_sshkey" hcl:"template_disable_sshkey"`
+	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name"`
+	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type"`
+	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug"`
+	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force"`
+	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error"`
+	PackerUserVars            map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables"`
+	PackerSensitiveVars       []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables"`
+	Type                      *string           `mapstructure:"communicator" cty:"communicator"`
+	PauseBeforeConnect        *string           `mapstructure:"pause_before_connecting" cty:"pause_before_connecting"`
+	SSHHost                   *string           `mapstructure:"ssh_host" cty:"ssh_host"`
+	SSHPort                   *int              `mapstructure:"ssh_port" cty:"ssh_port"`
+	SSHUsername               *string           `mapstructure:"ssh_username" cty:"ssh_username"`
+	SSHPassword               *string           `mapstructure:"ssh_password" cty:"ssh_password"`
+	SSHKeyPairName            *string           `mapstructure:"ssh_keypair_name" cty:"ssh_keypair_name"`
+	SSHTemporaryKeyPairName   *string           `mapstructure:"temporary_key_pair_name" cty:"temporary_key_pair_name"`
+	SSHClearAuthorizedKeys    *bool             `mapstructure:"ssh_clear_authorized_keys" cty:"ssh_clear_authorized_keys"`
+	SSHPrivateKeyFile         *string           `mapstructure:"ssh_private_key_file" cty:"ssh_private_key_file"`
+	SSHPty                    *bool             `mapstructure:"ssh_pty" cty:"ssh_pty"`
+	SSHTimeout                *string           `mapstructure:"ssh_timeout" cty:"ssh_timeout"`
+	SSHWaitTimeout            *string           `mapstructure:"ssh_wait_timeout" undocumented:"true" cty:"ssh_wait_timeout"`
+	SSHAgentAuth              *bool             `mapstructure:"ssh_agent_auth" cty:"ssh_agent_auth"`
+	SSHDisableAgentForwarding *bool             `mapstructure:"ssh_disable_agent_forwarding" cty:"ssh_disable_agent_forwarding"`
+	SSHHandshakeAttempts      *int              `mapstructure:"ssh_handshake_attempts" cty:"ssh_handshake_attempts"`
+	SSHBastionHost            *string           `mapstructure:"ssh_bastion_host" cty:"ssh_bastion_host"`
+	SSHBastionPort            *int              `mapstructure:"ssh_bastion_port" cty:"ssh_bastion_port"`
+	SSHBastionAgentAuth       *bool             `mapstructure:"ssh_bastion_agent_auth" cty:"ssh_bastion_agent_auth"`
+	SSHBastionUsername        *string           `mapstructure:"ssh_bastion_username" cty:"ssh_bastion_username"`
+	SSHBastionPassword        *string           `mapstructure:"ssh_bastion_password" cty:"ssh_bastion_password"`
+	SSHBastionInteractive     *bool             `mapstructure:"ssh_bastion_interactive" cty:"ssh_bastion_interactive"`
+	SSHBastionPrivateKeyFile  *string           `mapstructure:"ssh_bastion_private_key_file" cty:"ssh_bastion_private_key_file"`
+	SSHFileTransferMethod     *string           `mapstructure:"ssh_file_transfer_method" cty:"ssh_file_transfer_method"`
+	SSHProxyHost              *string           `mapstructure:"ssh_proxy_host" cty:"ssh_proxy_host"`
+	SSHProxyPort              *int              `mapstructure:"ssh_proxy_port" cty:"ssh_proxy_port"`
+	SSHProxyUsername          *string           `mapstructure:"ssh_proxy_username" cty:"ssh_proxy_username"`
+	SSHProxyPassword          *string           `mapstructure:"ssh_proxy_password" cty:"ssh_proxy_password"`
+	SSHKeepAliveInterval      *string           `mapstructure:"ssh_keep_alive_interval" cty:"ssh_keep_alive_interval"`
+	SSHReadWriteTimeout       *string           `mapstructure:"ssh_read_write_timeout" cty:"ssh_read_write_timeout"`
+	SSHRemoteTunnels          []string          `mapstructure:"ssh_remote_tunnels" cty:"ssh_remote_tunnels"`
+	SSHLocalTunnels           []string          `mapstructure:"ssh_local_tunnels" cty:"ssh_local_tunnels"`
+	SSHPublicKey              []byte            `mapstructure:"ssh_public_key" cty:"ssh_public_key"`
+	SSHPrivateKey             []byte            `mapstructure:"ssh_private_key" cty:"ssh_private_key"`
+	WinRMUser                 *string           `mapstructure:"winrm_username" cty:"winrm_username"`
+	WinRMPassword             *string           `mapstructure:"winrm_password" cty:"winrm_password"`
+	WinRMHost                 *string           `mapstructure:"winrm_host" cty:"winrm_host"`
+	WinRMPort                 *int              `mapstructure:"winrm_port" cty:"winrm_port"`
+	WinRMTimeout              *string           `mapstructure:"winrm_timeout" cty:"winrm_timeout"`
+	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl"`
+	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure"`
+	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm"`
+	APIEndpoint               *string           `mapstructure:"api_endpoint" cty:"api_endpoint"`
+	APIKey                    *string           `mapstructure:"api_key" cty:"api_key"`
+	APISecret                 *string           `mapstructure:"api_secret" cty:"api_secret"`
+	InstanceName              *string           `mapstructure:"instance_name" cty:"instance_name"`
+	InstanceZone              *string           `mapstructure:"instance_zone" cty:"instance_zone"`
+	InstanceTemplate          *string           `mapstructure:"instance_template" cty:"instance_template"`
+	InstanceTemplateFilter    *string           `mapstructure:"instance_template_filter" cty:"instance_template_filter"`
+	InstanceType              *string           `mapstructure:"instance_type" cty:"instance_type"`
+	InstanceDiskSize          *int64            `mapstructure:"instance_disk_size" cty:"instance_disk_size"`
+	InstanceSecurityGroup     *string           `mapstructure:"instance_security_group" cty:"instance_security_group"`
+	InstancePrivateNetworks   []string          `mapstructure:"instance_private_networks" cty:"instance_private_networks"`
+	InstanceSSHKey            *string           `mapstructure:"instance_ssh_key" cty:"instance_ssh_key"`
+	TemplateZone              *string           `mapstructure:"template_zone" cty:"template_zone"`
+	TemplateName              *string           `mapstructure:"template_name" cty:"template_name"`
+	TemplateDescription       *string           `mapstructure:"template_description" cty:"template_description"`
+	TemplateUsername          *string           `mapstructure:"template_username" cty:"template_username"`
+	TemplateBootMode          *string           `mapstructure:"template_boot_mode" cty:"template_boot_mode"`
+	TemplateDisablePassword   *bool             `mapstructure:"template_disable_password" cty:"template_disable_password"`
+	TemplateDisableSSHKey     *bool             `mapstructure:"template_disable_sshkey" cty:"template_disable_sshkey"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -149,6 +150,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"instance_type":                &hcldec.AttrSpec{Name: "instance_type", Type: cty.String, Required: false},
 		"instance_disk_size":           &hcldec.AttrSpec{Name: "instance_disk_size", Type: cty.Number, Required: false},
 		"instance_security_group":      &hcldec.AttrSpec{Name: "instance_security_group", Type: cty.String, Required: false},
+		"instance_private_networks":    &hcldec.AttrSpec{Name: "instance_private_networks", Type: cty.List(cty.String), Required: false},
 		"instance_ssh_key":             &hcldec.AttrSpec{Name: "instance_ssh_key", Type: cty.String, Required: false},
 		"template_zone":                &hcldec.AttrSpec{Name: "template_zone", Type: cty.String, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},

--- a/step_create_ssh_key.go
+++ b/step_create_ssh_key.go
@@ -44,7 +44,7 @@ func (s *stepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	config.Comm.SSHPrivateKey = []byte(sshKey.PrivateKey)
 	if config.PackerDebug {
 		sshPrivateKeyFile := config.InstanceSSHKey
-		if err := ioutil.WriteFile(sshPrivateKeyFile, config.Comm.SSHPrivateKey, 0600); err != nil {
+		if err := ioutil.WriteFile(sshPrivateKeyFile, config.Comm.SSHPrivateKey, 0o600); err != nil {
 			ui.Error(fmt.Sprintf("unable to write SSH private key to file: %s", err))
 			return multistep.ActionHalt
 		}
@@ -60,4 +60,4 @@ func (s *stepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	return multistep.ActionContinue
 }
 
-func (s *stepCreateSSHKey) Cleanup(state multistep.StateBag) {}
+func (s *stepCreateSSHKey) Cleanup(_ multistep.StateBag) {}

--- a/step_delete_ssh_key.go
+++ b/step_delete_ssh_key.go
@@ -34,4 +34,4 @@ func (s *stepDeleteSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	return multistep.ActionContinue
 }
 
-func (s *stepDeleteSSHKey) Cleanup(state multistep.StateBag) {}
+func (s *stepDeleteSSHKey) Cleanup(_ multistep.StateBag) {}

--- a/step_destroy_instance.go
+++ b/step_destroy_instance.go
@@ -29,4 +29,4 @@ func (s *stepDestroyInstance) Run(ctx context.Context, state multistep.StateBag)
 	return multistep.ActionContinue
 }
 
-func (s *stepDestroyInstance) Cleanup(state multistep.StateBag) {}
+func (s *stepDestroyInstance) Cleanup(_ multistep.StateBag) {}

--- a/step_export_snapshot.go
+++ b/step_export_snapshot.go
@@ -33,4 +33,4 @@ func (s *stepExportSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 	return multistep.ActionContinue
 }
 
-func (s *stepExportSnapshot) Cleanup(state multistep.StateBag) {}
+func (s *stepExportSnapshot) Cleanup(_ multistep.StateBag) {}

--- a/step_register_template.go
+++ b/step_register_template.go
@@ -61,4 +61,4 @@ func (s *stepRegisterTemplate) Run(ctx context.Context, state multistep.StateBag
 	return multistep.ActionContinue
 }
 
-func (s *stepRegisterTemplate) Cleanup(state multistep.StateBag) {}
+func (s *stepRegisterTemplate) Cleanup(_ multistep.StateBag) {}

--- a/step_snapshot_instance.go
+++ b/step_snapshot_instance.go
@@ -47,4 +47,4 @@ func (s *stepSnapshotInstance) Run(ctx context.Context, state multistep.StateBag
 	return multistep.ActionContinue
 }
 
-func (s *stepSnapshotInstance) Cleanup(state multistep.StateBag) {}
+func (s *stepSnapshotInstance) Cleanup(_ multistep.StateBag) {}

--- a/step_stop_instance.go
+++ b/step_stop_instance.go
@@ -29,4 +29,4 @@ func (s *stepStopInstance) Run(ctx context.Context, state multistep.StateBag) mu
 	return multistep.ActionContinue
 }
 
-func (s *stepStopInstance) Cleanup(state multistep.StateBag) {}
+func (s *stepStopInstance) Cleanup(_ multistep.StateBag) {}


### PR DESCRIPTION
This change introduces a new `instance_private_networks` configuration
setting, allowing users to attach Private Networks to the build Compute
instance.