### PR TITLE
Add support for multiple instance Security Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Here is the list of supported configuration parameters by the builder.
 - `instance_disk_size` (int) - Volume disk size in GB of the Compute instance
   to create. Defaults to `50`.
 
-- `instance_security_group` (string) - Security Group to use for the Compute
-  instance. Defaults to `default`.
+- `instance_security_groups` (list of strings) - List of Security Groups
+  (names) to apply to the Compute instance. Defaults to `["default"]`.
 
 - `instance_private_networks` (list of strings) - List of Private Networks
   (names) to attach to the Compute instance.
@@ -92,7 +92,8 @@ Here is the list of supported configuration parameters by the builder.
 - `template_username` (string) - An optional username to be used to log into
   Compute instances using this template.
 
-- `template_boot_mode` (string) - The template boot mode. Supported values: `legacy` (default), `uefi`.
+- `template_boot_mode` (string) - The template boot mode. Supported values:
+  `legacy` (default), `uefi`.
 
 - `template_disable_password` (boolean) - Whether the template should disable
   Compute instance password reset. Defaults to `false`.

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	InstanceTemplateFilter  string   `mapstructure:"instance_template_filter"`
 	InstanceType            string   `mapstructure:"instance_type"`
 	InstanceDiskSize        int64    `mapstructure:"instance_disk_size"`
-	InstanceSecurityGroup   string   `mapstructure:"instance_security_group"`
+	InstanceSecurityGroups  []string `mapstructure:"instance_security_groups"`
 	InstancePrivateNetworks []string `mapstructure:"instance_private_networks"`
 	InstanceSSHKey          string   `mapstructure:"instance_ssh_key"`
 	TemplateZone            string   `mapstructure:"template_zone"`
@@ -55,7 +55,7 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 		APIEndpoint:            defaultAPIEndpoint,
 		InstanceType:           defaultInstanceType,
 		InstanceDiskSize:       defaultInstanceDiskSize,
-		InstanceSecurityGroup:  defaultInstanceSecurityGroup,
+		InstanceSecurityGroups: []string{defaultInstanceSecurityGroup},
 		InstanceTemplateFilter: defaultInstanceTemplateFilter,
 	}
 

--- a/config.hcl2spec.go
+++ b/config.hcl2spec.go
@@ -67,7 +67,7 @@ type FlatConfig struct {
 	InstanceTemplateFilter    *string           `mapstructure:"instance_template_filter" cty:"instance_template_filter"`
 	InstanceType              *string           `mapstructure:"instance_type" cty:"instance_type"`
 	InstanceDiskSize          *int64            `mapstructure:"instance_disk_size" cty:"instance_disk_size"`
-	InstanceSecurityGroup     *string           `mapstructure:"instance_security_group" cty:"instance_security_group"`
+	InstanceSecurityGroups    []string          `mapstructure:"instance_security_groups" cty:"instance_security_groups"`
 	InstancePrivateNetworks   []string          `mapstructure:"instance_private_networks" cty:"instance_private_networks"`
 	InstanceSSHKey            *string           `mapstructure:"instance_ssh_key" cty:"instance_ssh_key"`
 	TemplateZone              *string           `mapstructure:"template_zone" cty:"template_zone"`
@@ -149,7 +149,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"instance_template_filter":     &hcldec.AttrSpec{Name: "instance_template_filter", Type: cty.String, Required: false},
 		"instance_type":                &hcldec.AttrSpec{Name: "instance_type", Type: cty.String, Required: false},
 		"instance_disk_size":           &hcldec.AttrSpec{Name: "instance_disk_size", Type: cty.Number, Required: false},
-		"instance_security_group":      &hcldec.AttrSpec{Name: "instance_security_group", Type: cty.String, Required: false},
+		"instance_security_groups":     &hcldec.AttrSpec{Name: "instance_security_groups", Type: cty.List(cty.String), Required: false},
 		"instance_private_networks":    &hcldec.AttrSpec{Name: "instance_private_networks", Type: cty.List(cty.String), Required: false},
 		"instance_ssh_key":             &hcldec.AttrSpec{Name: "instance_ssh_key", Type: cty.String, Required: false},
 		"template_zone":                &hcldec.AttrSpec{Name: "template_zone", Type: cty.String, Required: false},

--- a/config_test.go
+++ b/config_test.go
@@ -33,7 +33,7 @@ func TestNewConfig(t *testing.T) {
 	require.Equal(t, defaultAPIEndpoint, config.APIEndpoint)
 	require.Equal(t, defaultInstanceType, config.InstanceType)
 	require.Equal(t, defaultInstanceDiskSize, config.InstanceDiskSize)
-	require.Equal(t, defaultInstanceSecurityGroup, config.InstanceSecurityGroup)
+	require.Equal(t, []string{defaultInstanceSecurityGroup}, config.InstanceSecurityGroups)
 	require.Equal(t, defaultInstanceTemplateFilter, config.InstanceTemplateFilter)
 	require.Equal(t, config.InstanceZone, testConfigTemplateZone)
 	require.Equal(t, defaultTemplateBootMode, config.TemplateBootMode)

--- a/step_create_instance.go
+++ b/step_create_instance.go
@@ -64,7 +64,7 @@ func (s *stepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 		TemplateID:         instanceTemplate.ID,
 		RootDiskSize:       config.InstanceDiskSize,
 		KeyPair:            config.InstanceSSHKey,
-		SecurityGroupNames: []string{config.InstanceSecurityGroup},
+		SecurityGroupNames: config.InstanceSecurityGroups,
 		NetworkIDs:         privateNetworks,
 		ZoneID:             zone.ID,
 	})


### PR DESCRIPTION
This change replaces the `instance_security_group` configuration
settings with `instance_security_groups` to allow users to apply
multiple SGs to the build Compute instance.