### PR TITLE
Perform cleanup actions if requested

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/exoscale/egoscale"
 	"github.com/hashicorp/packer/common"
@@ -48,6 +49,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	ui.Say(fmt.Sprintf("Build ID: %s", b.buildID))
 
 	b.exo = egoscale.NewClient(b.config.APIEndpoint, b.config.APIKey, b.config.APISecret)
+	b.exo.Timeout = 5 * time.Minute
 
 	resp, err := b.exo.GetWithContext(ctx, &egoscale.ListZones{Name: b.config.InstanceZone})
 	if err != nil {

--- a/step_create_ssh_key.go
+++ b/step_create_ssh_key.go
@@ -60,4 +60,19 @@ func (s *stepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	return multistep.ActionContinue
 }
 
-func (s *stepCreateSSHKey) Cleanup(_ multistep.StateBag) {}
+func (s *stepCreateSSHKey) Cleanup(state multistep.StateBag) {
+	var (
+		exo    = state.Get("exo").(*egoscale.Client)
+		ui     = state.Get("ui").(packer.Ui)
+		config = state.Get("config").(*Config)
+	)
+
+	if state.Get("delete_ssh_key").(bool) {
+		ui.Say("Cleanup: deleting SSH key")
+
+		err := exo.BooleanRequest(&egoscale.DeleteSSHKeyPair{Name: config.InstanceSSHKey})
+		if err != nil {
+			ui.Error(fmt.Sprintf("unable to delete SSH key: %s", err))
+		}
+	}
+}


### PR DESCRIPTION
This change fixes a bug where the `-on-error=cleanup` build command flag
was not honored, leaving dangling resources in case of aborted build.