### PR TITLE
Fix Compute instance template usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,13 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+    - '**'
+    paths-ignore:
+    - '**.md'
+    tags-ignore:
+    - 'v*' # Don't run CI tests on release tags
 
 jobs:
   test:


### PR DESCRIPTION
This change improves the Compute instance template usage to avoid
returning an error if the user specifies a template name that matches
multiple results, and instead pick the most recent item.